### PR TITLE
Fix a test case bug

### DIFF
--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/GemsResultsAnalyzer.scala
@@ -130,10 +130,10 @@ object GemsResultsAnalyzer {
   }
 
   private def printResults(result: List[GemsGuideStars]) {
-    Log.info("Results:")
-    result.zipWithIndex.foreach { case (s, i) =>
-      Log.info(s"result #$i : $s")
-    }
+    // Log.info("Results:")
+    // result.zipWithIndex.foreach { case (s, i) =>
+    //   Log.info(s"result #$i : $s")
+    // }
   }
 
   private def sortResultsByRanking(list: List[GemsGuideStars]): List[GemsGuideStars] = {

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/Mascot.scala
@@ -26,11 +26,11 @@ object Mascot {
 
   // Default progress callback, called for each asterism as it is calculated
   val defaultProgress:ProgressFunction = (s: Strehl, count: Int, total: Int) => {
-    Log.info(s"Asterism #$count")
-    for (i <- s.stars.indices) {
-      Log.finer(s"[${s.stars(i).x}%.1f,${s.stars(i).y}%.1f]")
-    }
-    Log.info(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f  rms=${s.rmsstrehl * 100}%.1f  min=${s.minstrehl * 100}%.1f  max=${s.maxstrehl * 100}%.1f")
+    // Log.info(s"Asterism #$count")
+    // for (i <- s.stars.indices) {
+    //   Log.finer(s"[${s.stars(i).x}%.1f,${s.stars(i).y}%.1f]")
+    // }
+    // Log.info(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f  rms=${s.rmsstrehl * 100}%.1f  min=${s.minstrehl * 100}%.1f  max=${s.maxstrehl * 100}%.1f")
     true
   }
 
@@ -58,7 +58,7 @@ object Mascot {
   def computeStrehl(factor: Double, st: StarTriple): Option[Strehl] = {
     st match {
       case StarTriple(n1, Some(n2), n3) if !doesItFit(n1, n2, n3) =>
-        Log.warning("Skipped. Does not fit.")
+        // Log.warning("Skipped. Does not fit.")
         None
       case s                                  =>
         //          sdata = mascot_compute_strehl();
@@ -93,7 +93,7 @@ object Mascot {
     val pairs = AllPairsAndTriples.allPairs(filteredStarList)
     val total = trips.length + pairs.length + ns
 
-    Log.info(s"Mascot.findBestAsterism: input stars: $ns, total asterisms: $total")
+    // Log.info(s"Mascot.findBestAsterism: input stars: $ns, total asterisms: $total")
 
     // Compute strehl for a sets of stars
     @tailrec
@@ -211,7 +211,7 @@ object Mascot {
     } while (valid.sum > nstar_limit)
     crowd_rad -= 2
 
-    Log.info(s"Select stars: found optimum crowding radius=$crowd_rad")
+    // Log.info(s"Select stars: found optimum crowding radius=$crowd_rad")
 
     starList.zipWithIndex collect {
       case (s, i) if valid(i) != 0.0 => s

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/gems/mascot/MascotCat.scala
@@ -27,11 +27,11 @@ object MascotCat {
 
   // Default progress callback, called for each asterism as it is calculated
   val defaultProgress: ProgressFunction = (s: Strehl, count: Int, total: Int) => {
-    Log.info(s"Asterism #$count")
-    for (i <- s.stars.indices) {
-      Log.finer(s.stars(i).target.coordinates.toString)
-    }
-    Log.info(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f rms=${s.rmsstrehl * 100}%.1f min=${s.minstrehl * 100}%.1f max=${s.maxstrehl * 100}%.1f")
+    // Log.info(s"Asterism #$count")
+    // for (i <- s.stars.indices) {
+    //   Log.finer(s.stars(i).target.coordinates.toString)
+    // }
+    // Log.info(f"Strehl over ${s.halffield * 2}%.1f: avg=${s.avgstrehl * 100}%.1f rms=${s.rmsstrehl * 100}%.1f min=${s.minstrehl * 100}%.1f max=${s.maxstrehl * 100}%.1f")
     true
   }
 

--- a/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
+++ b/bundle/edu.gemini.ags/src/main/scala/edu/gemini/ags/impl/SingleProbeStrategy.scala
@@ -87,8 +87,8 @@ case class SingleProbeStrategy(key: AgsStrategyKey, params: SingleProbeStrategyP
   protected [ags] def select(ctx: ObsContext, mt: MagnitudeTable, candidates: List[SiderealTarget]): Option[AgsStrategy.Selection] = {
 
     // Temporary for Andy's tests.
-    def feedback(feedback: => String): Unit =
-      println(s"AGS $feedback")
+    def feedback(feedback: => String): Unit = ()
+      // println(s"AGS $feedback")
 
     def selectMinVigetting(vprobe: VProbe, allValid: List[(ObsContext, List[SiderealTarget])]): Option[AgsStrategy.Selection] = {
 

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/gems/GemsResultsAnalyzerSpec.scala
@@ -58,13 +58,13 @@ class GemsResultsAnalyzerSpec extends MascotProgress with Specification with NoT
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
 
-      results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
-      }
+      // results.zipWithIndex.foreach { case (r, i) =>
+      //   System.out.println("Result #" + i)
+      //   System.out.println(" Criteria:" + r.criterion)
+      //   System.out.println(" Results size:" + r.results.size)
+      // }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      // System.out.println("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 247
 
       val result = gemsGuideStars.head
@@ -119,13 +119,13 @@ class GemsResultsAnalyzerSpec extends MascotProgress with Specification with NoT
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
 
-      results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
-      }
+      // results.zipWithIndex.foreach { case (r, i) =>
+      //   System.out.println("Result #" + i)
+      //   System.out.println(" Criteria:" + r.criterion)
+      //   System.out.println(" Results size:" + r.results.size)
+      // }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      // System.out.println("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 135
 
       val result = gemsGuideStars.head
@@ -180,13 +180,13 @@ class GemsResultsAnalyzerSpec extends MascotProgress with Specification with NoT
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
 
-      results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
-      }
+      // results.zipWithIndex.foreach { case (r, i) =>
+      //   System.out.println("Result #" + i)
+      //   System.out.println(" Criteria:" + r.criterion)
+      //   System.out.println(" Results size:" + r.results.size)
+      // }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      // System.out.println("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 98
 
       val result = gemsGuideStars.head
@@ -241,13 +241,13 @@ class GemsResultsAnalyzerSpec extends MascotProgress with Specification with NoT
       val expectedResults = if (tipTiltMode == GemsTipTiltMode.both) 4 else 2
       results should have size expectedResults
 
-      results.zipWithIndex.foreach { case (r, i) =>
-        System.out.println("Result #" + i)
-        System.out.println(" Criteria:" + r.criterion)
-        System.out.println(" Results size:" + r.results.size)
-      }
+      // results.zipWithIndex.foreach { case (r, i) =>
+      //   System.out.println("Result #" + i)
+      //   System.out.println(" Criteria:" + r.criterion)
+      //   System.out.println(" Results size:" + r.results.size)
+      // }
 
-      System.out.println("gems results: size = " + gemsGuideStars.size)
+      // System.out.println("gems results: size = " + gemsGuideStars.size)
       gemsGuideStars should have size 54
 
       val result = gemsGuideStars.head

--- a/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
+++ b/bundle/edu.gemini.ags/src/test/scala/edu/gemini/ags/impl/GemsStrategySpec.scala
@@ -383,7 +383,7 @@ class GemsStrategySpec extends Specification with NoTimeConversions {
       selection.map(_.posAngle) should beSome(Angle.fromDegrees(90))
       val assignments = ~selection.map(_.assignments)
       assignments should be size 4
-      assignments.foreach(println)
+      // assignments.foreach(println)
 
       assignments.exists(_.guideProbe == Canopus.Wfs.cwfs1) should beTrue
       val cwfs1 = assignments.find(_.guideProbe == Canopus.Wfs.cwfs1).map(_.guideStar)

--- a/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/package.scala
+++ b/bundle/edu.gemini.dataman.app/src/main/scala/edu/gemini/dataman/package.scala
@@ -9,7 +9,7 @@ import edu.gemini.gsa.query.GsaResponse
 package object dataman {
   val DatamanLogger = Logger.getLogger("edu.gemini.dataman")
 
-  private val DetailLevelRef = new AtomicReference(Level.INFO)
+  private val DetailLevelRef = new AtomicReference(Level.FINE)
   private val JsonLevelRef   = new AtomicReference(Level.FINE)
 
   def DetailLevel: Level                = DetailLevelRef.get

--- a/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsLogActionsSpec.scala
+++ b/bundle/edu.gemini.dataman.app/src/test/scala/edu/gemini/dataman/app/ObsLogActionsSpec.scala
@@ -78,6 +78,11 @@ object ObsLogActionsSpec extends TestSupport {
         GsaRecord(Some(lab), f"$FilenamePrefix%s${index+1}%03d.fits", DatasetGsaState(DatasetQaState.UNDEFINED, Instant.now(), DatasetMd5.empty))
       }
 
+      // This test case generates "missing" datasets, which results in a warning
+      // to the console.  Since there are quite a few instances of this we'll up
+      // the log level to SEVERE to avoid seeing them here.
+      ObsLogActions.Log.setLevel(java.util.logging.Level.SEVERE)
+ 
       new ObsLogActions(odb).updateSummit(recs).unsafeRun match {
         case -\/(f) =>
           failure(f.explain)

--- a/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/VignettingCalculator.scala
+++ b/bundle/edu.gemini.pot/src/main/scala/edu/gemini/spModel/guide/VignettingCalculator.scala
@@ -59,9 +59,9 @@ sealed trait VignettingCalculator {
         case a :: as =>
           val vignetting = calc(f(a))
           if (curMin.forall(_._2 > vignetting)) {
-            curMin.foreach { case (t,d) =>
-              println(f"AGS rejecting ${formatCoordinates(f(t))}. Vignettes ${d*100}%.2f%%.")
-            }
+            // curMin.foreach { case (t,d) =>
+            //   println(f"AGS rejecting ${formatCoordinates(f(t))}. Vignettes ${d*100}%.2f%%.")
+            // }
             val newMin = Some((a, vignetting))
             if (vignetting == 0.0) newMin else go(as, newMin)
           } else go(as, curMin)

--- a/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
+++ b/bundle/edu.gemini.pot/src/test/scala/edu/gemini/spModel/template/InstantiationFunctorTest.scala
@@ -33,6 +33,10 @@ class InstantiationFunctorTest extends SpModelTestBase {
     val fact = getFactory
     val prog = getProgram
 
+    // Remove any existing observations.
+    prog.setObservations(java.util.Collections.emptyList())
+    prog.setGroups(java.util.Collections.emptyList())
+
     // Setup the test program with a single template group with a single target
     // at (RA, Dec) (1, 2) and CC50 observing conditions.
     val tfNode = fact.createTemplateFolder(prog, WithSomeNewKey)


### PR DESCRIPTION
The template folder is replaced multiple times in a single test, which causes existing observations to refer to template observations that no longer exist.  This update simply removes old instantiated observations to start from a clean slate.
